### PR TITLE
Bump owo-colors to 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 tracing-error = "0.2.0"
 tracing-core = "0.1.21"
-owo-colors = "3.2.0"
+owo-colors = "4.0"
 once_cell = "1.4.1"
 
 [dev-dependencies]


### PR DESCRIPTION
While this dependency update is technically identified as a breaking change, nothing seems to actually be all that different except that the MSRV raises to 1.56.